### PR TITLE
Return deviceId rather than device number for Volumes

### DIFF
--- a/src/main/java/org/dasein/cloud/cloudstack/compute/Volumes.java
+++ b/src/main/java/org/dasein/cloud/cloudstack/compute/Volumes.java
@@ -927,11 +927,13 @@ public class Volumes extends AbstractVolumeSupport {
         volume.setProviderRegionId(provider.getContext().getRegionId());
         volume.setProviderDataCenterId(provider.getContext().getRegionId());
 
-        volume.setDeviceId(deviceNumber);
+        Platform platform = Platform.guess(volume.getName() + " " + volume.getDescription());
+
+        volume.setDeviceId(toDeviceID(deviceNumber, platform.isWindows()));
         volume.setRootVolume(root);
         volume.setType(VolumeType.HDD);
         if( root ) {
-            volume.setGuestOperatingSystem(Platform.guess(volume.getName() + " " + volume.getDescription()));
+            volume.setGuestOperatingSystem(platform);
         }
         return volume;
     }


### PR DESCRIPTION
This was causing a problem in https://enstratus.fogbugz.com/default.asp?5119 since deviceNumbers (like 5,6,7) were being returned rather than ids (/dev/xvdh etc).
